### PR TITLE
Added the ability to pull from a redis list

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,1 @@
-recursive-include tests *
 include __init__.py

--- a/pytest_redis.py
+++ b/pytest_redis.py
@@ -2,21 +2,6 @@
 from _pytest.terminal import TerminalReporter
 import _pytest.runner
 import redis
-# Exit value when everything is okay
-from _pytest.main import EXIT_OK
-# Exit value when no tests are collected
-from _pytest.main import EXIT_NOTESTSCOLLECTED
-# Exit value whenever a single test fails
-from _pytest.main import EXIT_TESTSFAILED
-# Exit value when an exception is thrown by parser or KeyboardInterrupt
-from _pytest.main import EXIT_INTERRUPTED
-# Exit value when incorrect cmdline args are passed
-from _pytest.main import EXIT_USAGEERROR
-# Exit value when an internal error occurs
-from _pytest.main import EXIT_INTERNALERROR
-
-
-tests_collected = 0
 
 
 def pytest_addoption(parser):
@@ -92,28 +77,4 @@ def pytest_itemcollected(item):
     We jump the gun and execute the item in place instead of
     waiting for the run test loop.
     """
-    global tests_collected
-    tests_collected += 1
     _pytest.runner.pytest_runtest_protocol(item, None)
-
-
-def pytest_sessionfinish(session, exitstatus):
-    """Called when the entire test session is completed."""
-    global tests_collected
-    session.testscollected = tests_collected
-    # default returns
-    if (session.exitstatus in
-            (EXIT_INTERRUPTED, EXIT_INTERNALERROR, EXIT_USAGEERROR)):
-        return session.exitstatus
-
-    # adjust the return value because py.test doesn't know
-    # we run + collect tests
-    if session.exitstatus == EXIT_NOTESTSCOLLECTED:
-        if tests_collected == 0:
-            return EXIT_NOTESTSCOLLECTED
-        elif session.testsfailed:
-            return EXIT_TESTSFAILED
-        else:
-            return EXIT_OK
-    else:
-        return session.exitstatus

--- a/pytest_redis.py
+++ b/pytest_redis.py
@@ -68,7 +68,6 @@ def redis_test_generator(config, args_to_prepend):
 
     if val is None:
         term.write("No items in redis list '%s'\n" % redis_list_key)
-        term.write("Running all tests\n")
 
     while val is not None:
         yield val
@@ -103,9 +102,8 @@ def pytest_sessionfinish(session, exitstatus):
     global tests_collected
     session.testscollected = tests_collected
     # default returns
-    if (session.exitstatus == EXIT_INTERRUPTED or
-       session.exitstatus == EXIT_INTERNALERROR or
-       session.exitstatus == EXIT_USAGEERROR):
+    if (session.exitstatus in
+            (EXIT_INTERRUPTED, EXIT_INTERNALERROR, EXIT_USAGEERROR)):
         return session.exitstatus
 
     # adjust the return value because py.test doesn't know

--- a/pytest_redis.py
+++ b/pytest_redis.py
@@ -1,9 +1,6 @@
 """pytest-redis queue plugin implementation."""
-
-import redis
 from _pytest.terminal import TerminalReporter
 import _pytest.runner as Runner
-
 import redis
 
 
@@ -19,6 +16,7 @@ def pytest_addoption(parser):
                      type=str,
                      help=('The key of the redis list containing '
                            'the test paths to execute.'),
+                     choices=['RPOP', 'rpop', 'LPOP', 'lpop'],
                      default="RPOP")
     parser.addoption('--redis-list-key', metavar='redis_list_key',
                      type=str,
@@ -83,7 +81,4 @@ def pytest_collection_modifyitems(session, config, items):
     term = TerminalReporter(config)
     term.write("pytest-redis: Removing all collected "
                "items before call to runtest_loop.")
-    if len(items) == 0:
-        items[:] = []
-    else:
-        items[:] = [items[0]]
+    items[:] == []

--- a/pytest_redis.py
+++ b/pytest_redis.py
@@ -2,6 +2,21 @@
 from _pytest.terminal import TerminalReporter
 import _pytest.runner
 import redis
+# Exit value when everything is okay
+from _pytest.main import EXIT_OK
+# Exit value when no tests are collected
+from _pytest.main import EXIT_NOTESTSCOLLECTED
+# Exit value whenever a single test fails
+from _pytest.main import EXIT_TESTSFAILED
+# Exit value when an exception is thrown by parser or KeyboardInterrupt
+from _pytest.main import EXIT_INTERRUPTED
+# Exit value when incorrect cmdline args are passed
+from _pytest.main import EXIT_USAGEERROR
+# Exit value when an internal error occurs
+from _pytest.main import EXIT_INTERNALERROR
+
+
+tests_collected = 0
 
 
 def pytest_addoption(parser):
@@ -67,18 +82,40 @@ def pytest_cmdline_main(config):
     config.args = redis_test_generator(config, config.args)
 
 
+def pytest_runtest_protocol(item, nextitem):
+    """Called when an item is run. Returning true stops the hook chain."""
+    return True
+
+
 def pytest_itemcollected(item):
     """Called when an item is found in the collection.
 
     We jump the gun and execute the item in place instead of
     waiting for the run test loop.
     """
+    global tests_collected
+    tests_collected += 1
     _pytest.runner.pytest_runtest_protocol(item, None)
 
 
-def pytest_collection_modifyitems(session, config, items):
-    """Modify the list of items before they are sent to main test loop."""
-    term = TerminalReporter(config)
-    term.write("pytest-redis: Removing all collected "
-               "items before call to runtest_loop.")
-    items[:] = []
+def pytest_sessionfinish(session, exitstatus):
+    """Called when the entire test session is completed."""
+    global tests_collected
+    session.testscollected = tests_collected
+    # default returns
+    if (session.exitstatus == EXIT_INTERRUPTED or
+       session.exitstatus == EXIT_INTERNALERROR or
+       session.exitstatus == EXIT_USAGEERROR):
+        return session.exitstatus
+
+    # adjust the return value because py.test doesn't know
+    # we run + collect tests
+    if session.exitstatus == EXIT_NOTESTSCOLLECTED:
+        if tests_collected == 0:
+            return EXIT_NOTESTSCOLLECTED
+        elif session.testsfailed:
+            return EXIT_TESTSFAILED
+        else:
+            return EXIT_OK
+    else:
+        return session.exitstatus

--- a/pytest_redis.py
+++ b/pytest_redis.py
@@ -1,6 +1,6 @@
 """pytest-redis queue plugin implementation."""
 from _pytest.terminal import TerminalReporter
-import _pytest.runner as Runner
+import _pytest.runner
 import redis
 
 
@@ -73,7 +73,7 @@ def pytest_itemcollected(item):
     We jump the gun and execute the item in place instead of
     waiting for the run test loop.
     """
-    Runner.pytest_runtest_protocol(item, None)
+    _pytest.runner.pytest_runtest_protocol(item, None)
 
 
 def pytest_collection_modifyitems(session, config, items):
@@ -81,4 +81,4 @@ def pytest_collection_modifyitems(session, config, items):
     term = TerminalReporter(config)
     term.write("pytest-redis: Removing all collected "
                "items before call to runtest_loop.")
-    items[:] == []
+    items[:] = []

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from setuptools import setup
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 """Configuration of pytest tests."""
-
 import pytest
 import redis
 

--- a/tests/test_redis_pytest.py
+++ b/tests/test_redis_pytest.py
@@ -4,20 +4,10 @@ Tests should be launched from the root directory with:
 py.test --redis-port=<port> --redis-host=<host> --redis-list-key=<list_to_use>
 
 """
-# Exit value when everything is okay
-from _pytest.main import EXIT_OK
-# Exit value when no tests are collected
-from _pytest.main import EXIT_NOTESTSCOLLECTED
-# Exit value whenever a single test fails
-from _pytest.main import EXIT_TESTSFAILED
-# Exit value when an exception is thrown by parser or KeyboardInterrupt
-from _pytest.main import EXIT_INTERRUPTED
-# Exit value when incorrect cmdline args are passed
-from _pytest.main import EXIT_USAGEERROR
-
+import pytest_redis
 import threading
-
 import os.path
+
 
 def default_pytest_redis_args():
     """Return default options for each pytest execution."""
@@ -30,7 +20,7 @@ def get_option_array(option_dict):
 
 
 def create_test_file(testdir, filename, text):
-    """Creates a test file with the given name and text contents"""
+    """Create test file with the given name and text contents."""
     the_kwargs = {
         filename: text
     }
@@ -42,9 +32,28 @@ def create_test_file(testdir, filename, text):
 
     testdir.makefile(ext, **the_kwargs)
 
+
+def get_standard_args(option_dict):
+    """Returns standard pytest redis_args combinbed with option dict"""
+    return default_pytest_redis_args() + get_option_array(option_dict)
+
+
 def create_test_dir(testdir, dirname):
-    """Creates a test file with the given name and text contents"""
+    """Create test file with the given name and text contents."""
     testdir.mkdir(dirname)
+
+
+def setup_multiple_consumer_threads(testdir, py_test_args, num_threads):
+    """Return multiple threads that will run pytest with the given args."""
+    def run_consumer(testdir, test_args):
+        result = testdir.runpytest(*test_args)
+        assert result.ret != pytest_redis.EXIT_INTERRUPTED
+        assert result.ret != pytest_redis.EXIT_TESTSFAILED
+        assert result.ret == pytest_redis.EXIT_OK
+
+    return [threading.Thread(target=run_consumer, args=[testdir, py_test_args])
+            for i in range(num_threads)]
+
 
 def test_external_arguments(testdir, redis_connection, redis_args):
     """Ensure that the plugin doesn't intefere with other plugins."""
@@ -57,15 +66,14 @@ def test_external_arguments(testdir, redis_connection, redis_args):
                            test_file_name + "::test_run_should_run")
 
     junitxml_filename = "pytest.xml"
-    py_test_args = default_pytest_redis_args() + \
-        get_option_array(redis_args) + \
+    py_test_args = get_standard_args(redis_args) + \
         ['--junitxml=' + junitxml_filename]
 
     junitxml_path = str(testdir.tmpdir) + "/" + junitxml_filename
 
     result = testdir.runpytest(*py_test_args)
     assert os.path.exists(junitxml_path)
-    assert result.ret == EXIT_NOTESTSCOLLECTED
+    assert result.ret == pytest_redis.EXIT_OK
 
 
 def test_multiple_consumers(testdir, redis_connection, redis_args):
@@ -76,28 +84,37 @@ def test_multiple_consumers(testdir, redis_connection, redis_args):
         def test_multiple_consumers():
             assert True
     """)
-    for i in range(500):
+    for i in range(100):
         redis_connection.lpush(redis_args['redis-list-key'],
                                test_file_name + "::test_multiple_consumers")
 
-    py_test_args = default_pytest_redis_args() + ["-s"] + get_option_array(redis_args)
+    py_test_args = get_standard_args(redis_args)
 
-    def run_consumer(test_args):
-        result = testdir.runpytest(*test_args)
-        assert result.ret != EXIT_INTERRUPTED
-        assert result.ret != EXIT_TESTSFAILED
-        assert result.ret == EXIT_OK or result.ret == EXIT_NOTESTSCOLLECTED
-
-    threads = [threading.Thread(target=run_consumer, args=[py_test_args])
-               for i in range(5)]
+    threads = setup_multiple_consumer_threads(testdir, py_test_args, 5)
 
     for thread in threads:
         thread.start()
+
+    for i in range(100):
+        redis_connection.lpush(redis_args['redis-list-key'],
+                               test_file_name + "::test_multiple_consumers")
 
     for thread in threads:
         thread.join()
 
     assert redis_connection.llen(redis_args['redis-list-key']) == 0
+
+
+def test_no_consumption_of_item(testdir, redis_args):
+    """Make sure that we don't run tests when the list is empty."""
+    test_file_name = "test_not_used"
+    create_test_file(testdir, test_file_name, """
+        def test_run_should_run():
+            assert True
+    """)
+    py_test_args = get_standard_args(redis_args)
+    result = testdir.runpytest(*py_test_args)
+    assert result.ret == pytest_redis.EXIT_NOTESTSCOLLECTED
 
 
 def test_non_existent_test_name(testdir, redis_connection, redis_args):
@@ -111,9 +128,9 @@ def test_non_existent_test_name(testdir, redis_connection, redis_args):
     redis_connection.lpush(redis_args['redis-list-key'],
                            test_file_name + "::test_wrong_name")
 
-    py_test_args = default_pytest_redis_args() + get_option_array(redis_args)
+    py_test_args = get_standard_args(redis_args)
     result = testdir.runpytest(*py_test_args)
-    assert result.ret == EXIT_USAGEERROR
+    assert result.ret == pytest_redis.EXIT_USAGEERROR
 
 
 def test_module_test_name(testdir, redis_connection, redis_args):
@@ -140,7 +157,7 @@ def test_module_test_name(testdir, redis_connection, redis_args):
     create_test_dir(testdir, module_2_name)
     create_test_file(testdir, module_2_name + "/" + module_2_test_filename,
                      module_2_test_filename_contents)
-    py_test_args = default_pytest_redis_args() + get_option_array(redis_args)
+    py_test_args = get_standard_args(redis_args)
 
     for module in [module_1_name, module_2_name]:
         redis_connection.lpush(redis_args['redis-list-key'], module)
@@ -149,27 +166,14 @@ def test_module_test_name(testdir, redis_connection, redis_args):
             "*" + module + "*PASSED",
             "*" + module + "*PASSED"
         ])
-        assert result.ret == EXIT_NOTESTSCOLLECTED
-
-
-def test_no_consumption_of_item(testdir, redis_args):
-    """Make sure that we don't run tests when the list is empty."""
-    test_file_name = "test_not_used"
-    create_test_file(testdir, test_file_name, """
-        def test_run_should_run():
-            assert True
-    """)
-    py_test_args = default_pytest_redis_args() + get_option_array(redis_args)
-
-    result = testdir.runpytest(*py_test_args)
-    assert result.ret == EXIT_NOTESTSCOLLECTED
+        assert result.ret == pytest_redis.EXIT_OK
 
 
 def test_lr_pop_from_list(testdir, redis_connection, redis_args):
     """Specify rpop from redis list with --redis-pop-type=rpop."""
     test_file_name = "test_lr_pop_from_list.py"
 
-    create_test_file(testdir, test_file_name,"""
+    create_test_file(testdir, test_file_name, """
         def test_run0():
             assert False
 
@@ -177,7 +181,7 @@ def test_lr_pop_from_list(testdir, redis_connection, redis_args):
             assert True
     """)
 
-    py_test_args = default_pytest_redis_args() + get_option_array(redis_args)
+    py_test_args = get_standard_args(redis_args)
 
     pop_options = ['rpop', 'lpop', 'invalid']
 
@@ -194,15 +198,15 @@ def test_lr_pop_from_list(testdir, redis_connection, redis_args):
                 "*::test_run0 FAILED",
                 "*::test_run1 PASSED"
             ])
-            assert result.ret == EXIT_TESTSFAILED
+            assert result.ret == pytest_redis.EXIT_TESTSFAILED
         elif pop_dir == 'lpop':
             result.stdout.fnmatch_lines([
                 "*::test_run1 PASSED",
                 "*::test_run0 FAILED"
             ])
-            assert result.ret == EXIT_TESTSFAILED
+            assert result.ret == pytest_redis.EXIT_TESTSFAILED
         elif pop_dir == 'invalid':
             # Clean up redis list because we have an invalid cmd line opt
             redis_connection.rpop(redis_args['redis-list-key'])
             redis_connection.rpop(redis_args['redis-list-key'])
-            assert result.ret == EXIT_INTERRUPTED
+            assert result.ret == pytest_redis.EXIT_INTERRUPTED

--- a/tests/test_redis_pytest.py
+++ b/tests/test_redis_pytest.py
@@ -4,6 +4,8 @@ Tests should be launched from the root directory with:
 py.test --redis-port=<port> --redis-host=<host> --redis-list-key=<list_to_use>
 
 """
+# Exit value when everything is okay
+from _pytest.main import EXIT_OK
 # Exit value when no tests are collected
 from _pytest.main import EXIT_NOTESTSCOLLECTED
 # Exit value whenever a single test fails
@@ -21,6 +23,28 @@ def get_option_array(option_dict):
     """Return cmdline options for a dict in '--key=val' form."""
     return ["--{}={}".format(k, v) for k, v in option_dict.items()]
 
+
+def test_external_arguments(testdir, redis_connection, redis_args):
+    """Ensure that the plugin doesn't intefere with other plugins."""
+    import os.path
+    tmp_test_filename = "test_external_arguments.py"
+    testdir.makepyfile("""
+        def test_run_should_run():
+            assert True
+    """)
+    redis_connection.lpush(redis_args['redis-list-key'],
+                           tmp_test_filename + "::test_run_should_run")
+
+    junitxml_filename = "pytest.xml"
+    py_test_args = default_pytest_redis_args() + \
+        get_option_array(redis_args) + \
+        ['--junitxml=' + junitxml_filename]
+
+    junitxml_path = str(testdir.tmpdir) + "/" + junitxml_filename
+
+    result = testdir.runpytest(*py_test_args)
+    assert os.path.exists(junitxml_path)
+    assert result.ret == EXIT_OK
 
 def test_no_consumption_of_item(testdir, redis_args):
     """Make sure that we don't run tests when the list is empty."""

--- a/tests/test_redis_pytest.py
+++ b/tests/test_redis_pytest.py
@@ -1,145 +1,77 @@
 """Tests the pytest-redis with a running redis instance.
 
 Tests should be launched from the root directory with:
-py.test  --redis-port=<port> --redis-host=<host> --redis-list-key=<list_to_use>
+py.test --redis-port=<port> --redis-host=<host> --redis-list-key=<list_to_use>
 
 """
+# Exit value when no tests are collected
+from _pytest.main import EXIT_NOTESTSCOLLECTED
+# Exit value whenever a single test fails
+from _pytest.main import EXIT_TESTSFAILED
+# Exit value when an exception is thrown by parser or KeyboardInterrupt
+from _pytest.main import EXIT_INTERRUPTED
 
 
-def test_consumption_of_item(testdir, redis_args, redis_connection):
-    """Make sure that we can consume multiple items."""
-    [redis_connection.lpush(redis_args['redis-list-key'],
-                            "test_consumption_of_item.py::test_run" + str(i))
-        for i in range(5)]
+def default_pytest_redis_args():
+    """Return default options for each pytest execution."""
+    return ['-v', '-p', 'pytest_redis']
 
-    # create a temporary pytest test module
-    testdir.makepyfile("""
-        def test_run0():
-            assert True
 
-        def test_run1():
-            assert True
-
-        def test_run2():
-            assert True
-
-        def test_run3():
-            assert True
-
-        def test_run4():
-            assert True
-
-        def test_run5():
-            assert True
-    """)
-
-    # run pytest with the following cmd args
-    result = testdir.runpytest(
-        '-v',
-        '-p',
-        'pytest_redis',
-        *["--" + str(key) + "=" + str(val) for key, val in redis_args.items()]
-    )
-
-    result.stdout.fnmatch_lines_random([
-        "*::test_run4 PASSED",
-        "*::test_run3 PASSED",
-        "*::test_run2 PASSED",
-        "*::test_run1 PASSED",
-        "*::test_run0 PASSED"
-    ])
-
-    # make sure that that we get a '0' exit code for the testsuite
-    assert result.ret == 0
+def get_option_array(option_dict):
+    """Return cmdline options for a dict in '--key=val' form."""
+    return ["--{}={}".format(k, v) for k, v in option_dict.items()]
 
 
 def test_no_consumption_of_item(testdir, redis_args):
-    """Make sure that we can consume multiple items."""
-    # create a temporary pytest test module
+    """Make sure that we don't run tests when the list is empty."""
     testdir.makepyfile("""
         def test_run_should_run():
             assert True
     """)
+    py_test_args = default_pytest_redis_args() + get_option_array(redis_args)
 
-    # run pytest with the following cmd args
-    result = testdir.runpytest(
-        '-v',
-        '-p',
-        'pytest_redis',
-        *["--" + str(key) + "=" + str(val) for key, val in redis_args.items()]
-    )
-
-    result.stdout.fnmatch_lines_random([
-        "*No items in redis list*"
-    ])
-
-    # make sure that that we get a '0' exit code for the testsuite
-    assert result.ret == 5
+    result = testdir.runpytest(*py_test_args)
+    assert result.ret == EXIT_NOTESTSCOLLECTED
 
 
-def test_rpop_from_queue(testdir, redis_connection, redis_args):
-    """Specify rpop from redis queue with --redis-pop-type=rpop."""
-    [redis_connection.lpush(redis_args['redis-list-key'],
-                            "test_rpop_from_queue.py::test_run" + str(i))
-        for i in range(2)]
-    # create a temporary pytest test module
+def test_lr_pop_from_list(testdir, redis_connection, redis_args):
+    """Specify rpop from redis list with --redis-pop-type=rpop."""
+    tmp_test_filename = "test_lr_pop_from_list.py"
+
     testdir.makepyfile("""
         def test_run0():
-            assert True
+            assert False
 
         def test_run1():
             assert True
     """)
 
-    # run pytest with the following cmd args
-    result = testdir.runpytest(
-        '-v',
-        '-p',
-        'pytest_redis',
-        '--redis-pop-type=rpop',
-        *["--" + str(key) + "=" + str(val) for key, val in redis_args.items()]
-    )
+    py_test_args = default_pytest_redis_args() + get_option_array(redis_args)
 
-    # The order of the line match indicates if it was rpop-ed correctly
-    result.stdout.fnmatch_lines([
-        "*::test_run0 PASSED",
-        "*::test_run1 PASSED"
-    ])
+    pop_options = ['rpop', 'lpop', 'invalid']
 
-    # make sure that that we get a '0' exit code for the testsuite
-    assert result.ret == 0
+    for pop_dir in pop_options:
+        cur_args = py_test_args + ["--redis-pop-type=" + pop_dir]
+        # populate redis list with tests
+        for ind in range(2):
+            redis_connection.lpush(redis_args['redis-list-key'],
+                                   tmp_test_filename + "::test_run" + str(ind))
 
-
-def test_lpop_from_queue(testdir, redis_connection, redis_args):
-    """Specify lpop from redis queue with --redis-pop-type=lpop."""
-    [redis_connection.lpush(redis_args['redis-list-key'],
-                            "test_lpop_from_queue.py::test_run" + str(i))
-        for i in range(2)]
-    # create a temporary pytest test module
-    testdir.makepyfile("""
-        def test_run0():
-            assert True
-
-        def test_run1():
-            assert True
-    """)
-
-    # run pytest with the following cmd args
-    result = testdir.runpytest(
-        '-v',
-        '-p',
-        'pytest_redis',
-        '--redis-pop-type=lpop',
-        *["--" + str(key) + "=" + str(val) for key, val in redis_args.items()]
-    )
-    # The order of the line match indicates if it was lpop-ed correctly
-    result.stdout.fnmatch_lines([
-        "*::test_run1 PASSED",
-        "*::test_run0 PASSED"
-    ])
-
-    # make sure that that we get a '0' exit code for the testsuite
-    assert result.ret == 0
-
-
-
+        result = testdir.runpytest(*cur_args)
+        if pop_dir == 'rpop':
+            result.stdout.fnmatch_lines([
+                "*::test_run0 FAILED",
+                "*::test_run1 PASSED"
+            ])
+            assert result.ret == EXIT_TESTSFAILED
+        elif pop_dir == 'lpop':
+            result.stdout.fnmatch_lines([
+                "*::test_run1 PASSED",
+                "*::test_run0 FAILED"
+            ])
+            assert result.ret == EXIT_TESTSFAILED
+        elif pop_dir == 'invalid':
+            # Clean up redis list because we have an invalid cmd line opt
+            redis_connection.rpop(redis_args['redis-list-key'])
+            redis_connection.rpop(redis_args['redis-list-key'])
+            assert result.ret == EXIT_INTERRUPTED

--- a/tests/test_redis_pytest.py
+++ b/tests/test_redis_pytest.py
@@ -70,16 +70,15 @@ def test_no_consumption_of_item(testdir, redis_args):
     )
 
     result.stdout.fnmatch_lines_random([
-        "*No items in redis queue*",
-        "*::test_run_should_run PASSED"
+        "*No items in redis list*"
     ])
 
     # make sure that that we get a '0' exit code for the testsuite
-    assert result.ret == 0
+    assert result.ret == 5
 
 
 def test_rpop_from_queue(testdir, redis_connection, redis_args):
-    """Specify rpop from redis queue with --redis-pop-type=rpop works."""
+    """Specify rpop from redis queue with --redis-pop-type=rpop."""
     [redis_connection.lpush(redis_args['redis-list-key'],
                             "test_rpop_from_queue.py::test_run" + str(i))
         for i in range(2)]
@@ -112,7 +111,7 @@ def test_rpop_from_queue(testdir, redis_connection, redis_args):
 
 
 def test_lpop_from_queue(testdir, redis_connection, redis_args):
-    """Specify rpop from redis queue with --redis-pop-type=rpop works."""
+    """Specify lpop from redis queue with --redis-pop-type=lpop."""
     [redis_connection.lpush(redis_args['redis-list-key'],
                             "test_lpop_from_queue.py::test_run" + str(i))
         for i in range(2)]

--- a/tests/test_redis_pytest.py
+++ b/tests/test_redis_pytest.py
@@ -12,7 +12,12 @@ from _pytest.main import EXIT_NOTESTSCOLLECTED
 from _pytest.main import EXIT_TESTSFAILED
 # Exit value when an exception is thrown by parser or KeyboardInterrupt
 from _pytest.main import EXIT_INTERRUPTED
+# Exit value when incorrect cmdline args are passed
+from _pytest.main import EXIT_USAGEERROR
 
+import threading
+
+import os.path
 
 def default_pytest_redis_args():
     """Return default options for each pytest execution."""
@@ -24,16 +29,32 @@ def get_option_array(option_dict):
     return ["--{}={}".format(k, v) for k, v in option_dict.items()]
 
 
+def create_test_file(testdir, filename, text):
+    """Creates a test file with the given name and text contents"""
+    the_kwargs = {
+        filename: text
+    }
+    ext = ""
+    try:
+        ext = filename.split(".")[-1]
+    except:
+        pass
+
+    testdir.makefile(ext, **the_kwargs)
+
+def create_test_dir(testdir, dirname):
+    """Creates a test file with the given name and text contents"""
+    testdir.mkdir(dirname)
+
 def test_external_arguments(testdir, redis_connection, redis_args):
     """Ensure that the plugin doesn't intefere with other plugins."""
-    import os.path
-    tmp_test_filename = "test_external_arguments.py"
-    testdir.makepyfile("""
+    test_file_name = "test_external_arguments.py"
+    create_test_file(testdir, test_file_name, """
         def test_run_should_run():
             assert True
     """)
     redis_connection.lpush(redis_args['redis-list-key'],
-                           tmp_test_filename + "::test_run_should_run")
+                           test_file_name + "::test_run_should_run")
 
     junitxml_filename = "pytest.xml"
     py_test_args = default_pytest_redis_args() + \
@@ -44,11 +65,97 @@ def test_external_arguments(testdir, redis_connection, redis_args):
 
     result = testdir.runpytest(*py_test_args)
     assert os.path.exists(junitxml_path)
-    assert result.ret == EXIT_OK
+    assert result.ret == EXIT_NOTESTSCOLLECTED
+
+
+def test_multiple_consumers(testdir, redis_connection, redis_args):
+    """Pull tests from multiple test runs simultaneously."""
+    test_file_name = "test_multiple_consumers.py"
+
+    create_test_file(testdir, test_file_name, """
+        def test_multiple_consumers():
+            assert True
+    """)
+    for i in range(500):
+        redis_connection.lpush(redis_args['redis-list-key'],
+                               test_file_name + "::test_multiple_consumers")
+
+    py_test_args = default_pytest_redis_args() + ["-s"] + get_option_array(redis_args)
+
+    def run_consumer(test_args):
+        result = testdir.runpytest(*test_args)
+        assert result.ret != EXIT_INTERRUPTED
+        assert result.ret != EXIT_TESTSFAILED
+        assert result.ret == EXIT_OK or result.ret == EXIT_NOTESTSCOLLECTED
+
+    threads = [threading.Thread(target=run_consumer, args=[py_test_args])
+               for i in range(5)]
+
+    for thread in threads:
+        thread.start()
+
+    for thread in threads:
+        thread.join()
+
+    assert redis_connection.llen(redis_args['redis-list-key']) == 0
+
+
+def test_non_existent_test_name(testdir, redis_connection, redis_args):
+    """Entire test should fail if a non-existent test is specfied."""
+    test_file_name = "test_name.py"
+    create_test_file(testdir, test_file_name, """
+        def test_name_dne():
+            assert True
+    """)
+
+    redis_connection.lpush(redis_args['redis-list-key'],
+                           test_file_name + "::test_wrong_name")
+
+    py_test_args = default_pytest_redis_args() + get_option_array(redis_args)
+    result = testdir.runpytest(*py_test_args)
+    assert result.ret == EXIT_USAGEERROR
+
+
+def test_module_test_name(testdir, redis_connection, redis_args):
+    """Test path as a module name."""
+    module_1_name = "test_module_1"
+    module_1_test_filename = "test_module_1_file.py"
+    module_1_test_filename_contents = """
+        def test_does_exist():
+            assert True
+        def test_random_test():
+            assert True
+    """
+    module_2_name = "test_module_2"
+    module_2_test_filename = "test_module_2_file.py"
+    module_2_test_filename_contents = """
+        def test_does_exist_2():
+            assert True
+        def test_random_test_2():
+            assert True
+    """
+    create_test_dir(testdir, module_1_name)
+    create_test_file(testdir, module_1_name + "/" + module_1_test_filename,
+                     module_1_test_filename_contents)
+    create_test_dir(testdir, module_2_name)
+    create_test_file(testdir, module_2_name + "/" + module_2_test_filename,
+                     module_2_test_filename_contents)
+    py_test_args = default_pytest_redis_args() + get_option_array(redis_args)
+
+    for module in [module_1_name, module_2_name]:
+        redis_connection.lpush(redis_args['redis-list-key'], module)
+        result = testdir.runpytest(*py_test_args)
+        result.stdout.fnmatch_lines([
+            "*" + module + "*PASSED",
+            "*" + module + "*PASSED"
+        ])
+        assert result.ret == EXIT_NOTESTSCOLLECTED
+
 
 def test_no_consumption_of_item(testdir, redis_args):
     """Make sure that we don't run tests when the list is empty."""
-    testdir.makepyfile("""
+    test_file_name = "test_not_used"
+    create_test_file(testdir, test_file_name, """
         def test_run_should_run():
             assert True
     """)
@@ -60,9 +167,9 @@ def test_no_consumption_of_item(testdir, redis_args):
 
 def test_lr_pop_from_list(testdir, redis_connection, redis_args):
     """Specify rpop from redis list with --redis-pop-type=rpop."""
-    tmp_test_filename = "test_lr_pop_from_list.py"
+    test_file_name = "test_lr_pop_from_list.py"
 
-    testdir.makepyfile("""
+    create_test_file(testdir, test_file_name,"""
         def test_run0():
             assert False
 
@@ -79,7 +186,7 @@ def test_lr_pop_from_list(testdir, redis_connection, redis_args):
         # populate redis list with tests
         for ind in range(2):
             redis_connection.lpush(redis_args['redis-list-key'],
-                                   tmp_test_filename + "::test_run" + str(ind))
+                                   test_file_name + "::test_run" + str(ind))
 
         result = testdir.runpytest(*cur_args)
         if pop_dir == 'rpop':


### PR DESCRIPTION
Fixes issue #2 

This pulls off test paths from a redis instance in the collection phase of the pytest runner. It also outputs a correct return value for the test.

@cfournie @damnMeddlingKid
